### PR TITLE
CORP-318 ~ Add publication content types attachment and external URL to a fieldgroup

### DIFF
--- a/project/config/nisra/config/core.entity_form_display.node.publication.default.yml
+++ b/project/config/nisra/config/core.entity_form_display.node.publication.default.yml
@@ -32,7 +32,7 @@ third_party_settings:
       label: Featured
       region: content
       parent_name: ''
-      weight: 10
+      weight: 11
       format_type: fieldset
       format_settings:
         classes: ''
@@ -40,6 +40,21 @@ third_party_settings:
         id: ''
         description: ''
         required_fields: false
+    group_publications:
+      children:
+        - field_external_publication
+        - field_attachment
+      label: Publications
+      region: content
+      parent_name: ''
+      weight: 17
+      format_type: fieldset
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        description: 'You must provide an attachment or external link'
+        required_fields: true
 _core:
   default_config_hash: ocDOtKu-FFvYTRQKCbgjXCZHYM6AqzhixwjVfYUoALI
 id: node.publication.default
@@ -65,7 +80,7 @@ content:
     third_party_settings: {  }
   field_attachment:
     type: media_library_widget
-    weight: 18
+    weight: 19
     region: content
     settings:
       media_types: {  }
@@ -74,7 +89,7 @@ content:
         show_edit: '1'
   field_external_publication:
     type: link_default
-    weight: 17
+    weight: 18
     region: content
     settings:
       placeholder_url: ''
@@ -82,7 +97,7 @@ content:
     third_party_settings: {  }
   field_meta_tags:
     type: metatag_firehose
-    weight: 19
+    weight: 20
     region: content
     settings:
       sidebar: true

--- a/project/config/nisra/config/core.entity_form_display.node.secure_market_statistics.default.yml
+++ b/project/config/nisra/config/core.entity_form_display.node.secure_market_statistics.default.yml
@@ -17,6 +17,7 @@ dependencies:
   module:
     - content_moderation
     - datetime
+    - field_group
     - link
     - media_library
     - media_library_edit
@@ -24,6 +25,23 @@ dependencies:
     - path
     - shs
     - text
+third_party_settings:
+  field_group:
+    group_publications:
+      children:
+        - field_external_publication
+        - field_secure_attachment
+      label: Publications
+      region: content
+      parent_name: ''
+      weight: 16
+      format_type: fieldset
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        description: 'You must provide an attachment or external link'
+        required_fields: true
 id: node.secure_market_statistics.default
 targetEntityType: node
 bundle: secure_market_statistics
@@ -47,7 +65,7 @@ content:
     third_party_settings: {  }
   field_external_publication:
     type: link_default
-    weight: 16
+    weight: 17
     region: content
     settings:
       placeholder_url: ''
@@ -55,7 +73,7 @@ content:
     third_party_settings: {  }
   field_meta_tags:
     type: metatag_firehose
-    weight: 17
+    weight: 19
     region: content
     settings:
       sidebar: true
@@ -85,7 +103,7 @@ content:
     third_party_settings: {  }
   field_secure_attachment:
     type: media_library_widget
-    weight: 26
+    weight: 18
     region: content
     settings:
       media_types: {  }

--- a/project/config/nisra/config/core.entity_form_display.node.secure_statistics.default.yml
+++ b/project/config/nisra/config/core.entity_form_display.node.secure_statistics.default.yml
@@ -17,6 +17,7 @@ dependencies:
   module:
     - content_moderation
     - datetime
+    - field_group
     - link
     - media_library
     - media_library_edit
@@ -24,6 +25,23 @@ dependencies:
     - path
     - shs
     - text
+third_party_settings:
+  field_group:
+    group_publications:
+      children:
+        - field_external_publication
+        - field_secure_attachment
+      label: Publications
+      region: content
+      parent_name: ''
+      weight: 18
+      format_type: fieldset
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        description: 'You must provide an attachment or external link'
+        required_fields: true
 id: node.secure_statistics.default
 targetEntityType: node
 bundle: secure_statistics
@@ -55,7 +73,7 @@ content:
     third_party_settings: {  }
   field_meta_tags:
     type: metatag_firehose
-    weight: 14
+    weight: 13
     region: content
     settings:
       sidebar: true
@@ -85,7 +103,7 @@ content:
     third_party_settings: {  }
   field_secure_attachment:
     type: media_library_widget
-    weight: 26
+    weight: 11
     region: content
     settings:
       media_types: {  }
@@ -124,33 +142,33 @@ content:
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 17
+    weight: 16
     region: content
     settings: {  }
     third_party_settings: {  }
   path:
     type: path
-    weight: 15
+    weight: 14
     region: content
     settings: {  }
     third_party_settings: {  }
   promote:
     type: boolean_checkbox
-    weight: 12
+    weight: 11
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 18
+    weight: 17
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
-    weight: 13
+    weight: 12
     region: content
     settings:
       display_label: true
@@ -174,7 +192,7 @@ content:
       placeholder: ''
     third_party_settings: {  }
   url_redirects:
-    weight: 16
+    weight: 15
     region: content
     settings: {  }
     third_party_settings: {  }


### PR DESCRIPTION
This still needs themed to make the guidance that one of the fields must be completed more obvious. There is a separate ticket to improve the admin theme.