### PR TITLE
CORP-616, CORP-618 & CORP-619

### DIFF
--- a/project/config/etini/config/core.date_format.medium.yml
+++ b/project/config/etini/config/core.date_format.medium.yml
@@ -7,4 +7,4 @@ _core:
 id: medium
 label: 'Default medium date'
 locked: false
-pattern: 'D, m/d/Y - H:i'
+pattern: 'D, d/m/Y - H:i'

--- a/project/config/etini/config/core.date_format.short.yml
+++ b/project/config/etini/config/core.date_format.short.yml
@@ -7,4 +7,4 @@ _core:
 id: short
 label: 'Default short date'
 locked: false
-pattern: 'm/d/Y - H:i'
+pattern: 'd/m/Y - H:i'

--- a/project/config/hseni/config/core.date_format.medium.yml
+++ b/project/config/hseni/config/core.date_format.medium.yml
@@ -7,4 +7,4 @@ _core:
 id: medium
 label: 'Default medium date'
 locked: false
-pattern: 'D, m/d/Y - H:i'
+pattern: 'D, d/m/Y - H:i'

--- a/project/config/hseni/config/core.date_format.short.yml
+++ b/project/config/hseni/config/core.date_format.short.yml
@@ -7,4 +7,4 @@ _core:
 id: short
 label: 'Default short date'
 locked: false
-pattern: 'm/d/Y - H:i'
+pattern: 'd/m/Y - H:i'

--- a/project/config/hseni/config/field.field.node.article.field_site_topics.yml
+++ b/project/config/hseni/config/field.field.node.article.field_site_topics.yml
@@ -12,7 +12,7 @@ id: node.article.field_site_topics
 field_name: field_site_topics
 entity_type: node
 bundle: article
-label: 'Site topics'
+label: Topics
 description: 'Choose relevant site topic(s) for this article. Hold down Ctrl to choose multiple site topics.'
 required: true
 translatable: false

--- a/project/config/hseni/config/field.field.node.consultation.field_published_date.yml
+++ b/project/config/hseni/config/field.field.node.consultation.field_published_date.yml
@@ -17,7 +17,10 @@ label: 'Published date'
 description: 'Please select the published date for this consultation, or accept the default value of today.'
 required: true
 translatable: false
-default_value: {  }
+default_value:
+  -
+    default_date_type: now
+    default_date: now
 default_value_callback: ''
 settings: {  }
 field_type: datetime

--- a/project/config/hseni/config/field.field.node.consultation.field_site_topics.yml
+++ b/project/config/hseni/config/field.field.node.consultation.field_site_topics.yml
@@ -12,7 +12,7 @@ id: node.consultation.field_site_topics
 field_name: field_site_topics
 entity_type: node
 bundle: consultation
-label: 'Site topics'
+label: Topics
 description: 'Choose relevant site topic(s) for this consultation. Hold down Ctrl to choose multiple site topics.'
 required: false
 translatable: false

--- a/project/config/hseni/config/field.field.node.link.field_site_topics.yml
+++ b/project/config/hseni/config/field.field.node.link.field_site_topics.yml
@@ -10,7 +10,7 @@ id: node.link.field_site_topics
 field_name: field_site_topics
 entity_type: node
 bundle: link
-label: 'Site topics'
+label: Topics
 description: 'Choose optional site topics for this link.'
 required: false
 translatable: false

--- a/project/config/hseni/config/field.field.node.news.field_site_topics.yml
+++ b/project/config/hseni/config/field.field.node.news.field_site_topics.yml
@@ -12,7 +12,7 @@ id: node.news.field_site_topics
 field_name: field_site_topics
 entity_type: node
 bundle: news
-label: 'Site topics'
+label: Topics
 description: 'Choose optional site topic(s) for this news item. Hold down Ctrl to choose multiple site topics.'
 required: false
 translatable: false


### PR DESCRIPTION
- CORP-616 - US Short date removed for revision screen, UK date setting added (HSENI and ETINI)
- CORP-618 - Minor inconsistency on topics label fixed to just show 'Topics' not 'Site Topics'
- CORP-619 - Consultation Published date on HSENI set to current date as default