### PR TITLE
CORP-648

### DIFF
--- a/project/config/etini/config/core.entity_form_display.node.publication.default.yml
+++ b/project/config/etini/config/core.entity_form_display.node.publication.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.publication.body
     - field.field.node.publication.field_attachment
     - field.field.node.publication.field_audience
+    - field.field.node.publication.field_html_document
     - field.field.node.publication.field_meta_tags
     - field.field.node.publication.field_publication_type
     - field.field.node.publication.field_published_date
@@ -27,8 +28,7 @@ dependencies:
 third_party_settings:
   field_group:
     group_featured:
-      children:
-        - field_feature_home_page
+      children: {  }
       label: Featured
       region: content
       parent_name: ''
@@ -81,6 +81,16 @@ content:
       create_new_items: false
       create_new_levels: false
       force_deepest: false
+    third_party_settings: {  }
+  field_html_document:
+    type: entity_reference_autocomplete
+    weight: 26
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
   field_meta_tags:
     type: metatag_firehose

--- a/project/config/etini/config/core.entity_view_display.node.html_document.default.yml
+++ b/project/config/etini/config/core.entity_view_display.node.html_document.default.yml
@@ -21,6 +21,7 @@ content:
     weight: 0
     region: content
 hidden:
+  content_moderation_control: true
   langcode: true
   links: true
   search_api_excerpt: true

--- a/project/config/etini/config/core.entity_view_display.node.html_document.embed.yml
+++ b/project/config/etini/config/core.entity_view_display.node.html_document.embed.yml
@@ -27,6 +27,7 @@ content:
     weight: 0
     region: content
 hidden:
+  content_moderation_control: true
   langcode: true
   links: true
   search_api_excerpt: true

--- a/project/config/etini/config/core.entity_view_display.node.html_document.full.yml
+++ b/project/config/etini/config/core.entity_view_display.node.html_document.full.yml
@@ -27,6 +27,7 @@ content:
     weight: 0
     region: content
 hidden:
+  content_moderation_control: true
   langcode: true
   links: true
   search_api_excerpt: true

--- a/project/config/etini/config/core.entity_view_display.node.publication.default.yml
+++ b/project/config/etini/config/core.entity_view_display.node.publication.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.publication.body
     - field.field.node.publication.field_attachment
     - field.field.node.publication.field_audience
+    - field.field.node.publication.field_html_document
     - field.field.node.publication.field_meta_tags
     - field.field.node.publication.field_publication_type
     - field.field.node.publication.field_published_date
@@ -15,8 +16,32 @@ dependencies:
     - node.type.publication
   module:
     - datetime
+    - field_group
     - text
     - user
+third_party_settings:
+  field_group:
+    group_documents:
+      children:
+        - field_attachment
+        - field_html_document
+      label: Documents
+      parent_name: ''
+      region: content
+      weight: 6
+      format_type: html_element
+      format_settings:
+        classes: list--no-bullet
+        show_empty_fields: false
+        id: ''
+        label_as_html: false
+        element: ul
+        show_label: false
+        label_element: h3
+        label_element_classes: ''
+        attributes: ''
+        effect: none
+        speed: fast
 _core:
   default_config_hash: QfGYPWOh9KP3TIFrvpeCzgESHvyquGW0HFe-b8Sg7X0
 id: node.publication.default
@@ -33,12 +58,21 @@ content:
     region: content
   field_attachment:
     type: entity_reference_entity_view
-    label: above
+    label: hidden
     settings:
       view_mode: embed
       link: false
     third_party_settings: {  }
-    weight: 6
+    weight: 7
+    region: content
+  field_html_document:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: embed
+      link: false
+    third_party_settings: {  }
+    weight: 8
     region: content
   field_publication_type:
     type: entity_reference_label

--- a/project/config/etini/config/core.entity_view_display.node.publication.diff.yml
+++ b/project/config/etini/config/core.entity_view_display.node.publication.diff.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.publication.body
     - field.field.node.publication.field_attachment
     - field.field.node.publication.field_audience
+    - field.field.node.publication.field_html_document
     - field.field.node.publication.field_meta_tags
     - field.field.node.publication.field_publication_type
     - field.field.node.publication.field_published_date
@@ -24,7 +25,6 @@ third_party_settings:
   field_group:
     group_additional_content_details:
       children:
-        - field_feature_home_page
         - field_audience
         - field_meta_tags
       label: 'Additional content details'
@@ -73,6 +73,15 @@ content:
       link: false
     third_party_settings: {  }
     weight: 8
+    region: content
+  field_html_document:
+    type: entity_reference_entity_view
+    label: above
+    settings:
+      view_mode: embed
+      link: false
+    third_party_settings: {  }
+    weight: 7
     region: content
   field_meta_tags:
     type: metatag_empty_formatter

--- a/project/config/etini/config/core.entity_view_display.node.publication.most_recent.yml
+++ b/project/config/etini/config/core.entity_view_display.node.publication.most_recent.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.publication.body
     - field.field.node.publication.field_attachment
     - field.field.node.publication.field_audience
+    - field.field.node.publication.field_html_document
     - field.field.node.publication.field_meta_tags
     - field.field.node.publication.field_publication_type
     - field.field.node.publication.field_published_date
@@ -43,6 +44,7 @@ hidden:
   content_moderation_control: true
   field_attachment: true
   field_audience: true
+  field_html_document: true
   field_meta_tags: true
   field_publication_type: true
   field_reference: true

--- a/project/config/etini/config/core.entity_view_display.node.publication.search_index.yml
+++ b/project/config/etini/config/core.entity_view_display.node.publication.search_index.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.publication.body
     - field.field.node.publication.field_attachment
     - field.field.node.publication.field_audience
+    - field.field.node.publication.field_html_document
     - field.field.node.publication.field_meta_tags
     - field.field.node.publication.field_publication_type
     - field.field.node.publication.field_published_date
@@ -76,6 +77,7 @@ hidden:
   content_moderation_control: true
   field_attachment: true
   field_audience: true
+  field_html_document: true
   field_meta_tags: true
   field_reference: true
   field_site_topics: true

--- a/project/config/etini/config/core.entity_view_display.node.publication.teaser.yml
+++ b/project/config/etini/config/core.entity_view_display.node.publication.teaser.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.publication.body
     - field.field.node.publication.field_attachment
     - field.field.node.publication.field_audience
+    - field.field.node.publication.field_html_document
     - field.field.node.publication.field_meta_tags
     - field.field.node.publication.field_publication_type
     - field.field.node.publication.field_published_date
@@ -36,6 +37,7 @@ hidden:
   content_moderation_control: true
   field_attachment: true
   field_audience: true
+  field_html_document: true
   field_meta_tags: true
   field_publication_type: true
   field_published_date: true

--- a/project/config/etini/config/field.field.node.publication.field_html_document.yml
+++ b/project/config/etini/config/field.field.node.publication.field_html_document.yml
@@ -1,0 +1,29 @@
+uuid: b3976204-eed8-4740-bda2-cbdd57ec96b5
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_html_document
+    - node.type.html_document
+    - node.type.publication
+id: node.publication.field_html_document
+field_name: field_html_document
+entity_type: node
+bundle: publication
+label: 'HTML document'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:node'
+  handler_settings:
+    target_bundles:
+      html_document: html_document
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/project/config/etini/config/field.storage.node.field_html_document.yml
+++ b/project/config/etini/config/field.storage.node.field_html_document.yml
@@ -1,0 +1,19 @@
+uuid: 7a2b8b7d-869b-48ec-842a-cd53aa88c609
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_html_document
+field_name: field_html_document
+entity_type: node
+type: entity_reference
+settings:
+  target_type: node
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/project/config/etini/config/pathauto.pattern.html_document_pattern.yml
+++ b/project/config/etini/config/pathauto.pattern.html_document_pattern.yml
@@ -1,0 +1,22 @@
+uuid: 30c2abc3-53a4-461a-9273-8aec6f182326
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: html_document_pattern
+label: 'HTML Document Pattern'
+type: 'canonical_entities:node'
+pattern: 'publications/html-document/[node:title]'
+selection_criteria:
+  38ec949c-1fab-472e-bbc8-e86075126b42:
+    id: 'entity_bundle:node'
+    negate: false
+    uuid: 38ec949c-1fab-472e-bbc8-e86075126b42
+    context_mapping:
+      node: node
+    bundles:
+      html_document: html_document
+selection_logic: and
+weight: -5
+relationships: {  }

--- a/project/sites/etini/themes/etini_theme/etini_theme.theme
+++ b/project/sites/etini/themes/etini_theme/etini_theme.theme
@@ -195,3 +195,21 @@ function corplite_social_links() {
 
   return $social_links;
 }
+
+function etini_theme_preprocess_field(array &$variables) {
+  if ($variables['element']['#field_name'] === 'field_html_document') {
+    foreach ($variables['items'] as $key => &$item) {
+
+      if (!empty($variables['element']['#items'][$key]) && $variables['element']['#items'][$key]->entity) {
+        $node = $variables['element']['#items'][$key]->entity;
+        if ($node->bundle() === 'html_document') {
+          $url = Url::fromRoute('entity.node.canonical', ['node' => $node->id()], [
+            'attributes' => ['class' => ['file-link', 'file--ico', 'file--ico__html']],
+          ]);
+          $link = Link::fromTextAndUrl($node->label(), $url)->toRenderable();
+          $item['content'] = $link;
+        }
+      }
+    }
+  }
+}

--- a/project/sites/etini/themes/etini_theme/templates/field/field--field-attachment.html.twig
+++ b/project/sites/etini/themes/etini_theme/templates/field/field--field-attachment.html.twig
@@ -1,0 +1,44 @@
+{#
+/**
+ * @file
+ * Theme override for a field.
+ *
+ * To override output, copy the "field.html.twig" from the templates directory
+ * to your theme's directory and customize it, just like customizing other
+ * Drupal templates such as page.html.twig or node.html.twig.
+ *
+ * Instead of overriding the theming for all fields, you can also just override
+ * theming for a subset of fields using
+ * @link themeable Theme hook suggestions. @endlink For example,
+ * here are some theme hook suggestions that can be used for a field_foo field
+ * on an article node type:
+ * - field--node--field-foo--article.html.twig
+ * - field--node--field-foo.html.twig
+ * - field--node--article.html.twig
+ * - field--field-foo.html.twig
+ * - field--text-with-summary.html.twig
+ * - field.html.twig
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - label_hidden: Whether to show the field label or not.
+ * - title_attributes: HTML attributes for the title.
+ * - label: The label for the field.
+ * - multiple: TRUE if a field can contain multiple items.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item's content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ * - node_id: Finding the node id of the help viewing documnents node on the
+ *   a per unity site basis. See nicsdru_unity_theme_preprocess_field().
+ *
+ * @see template_preprocess_field()
+ */
+#}
+{% for item in items %}
+  <li{{ item.attributes.addClass('list-item') }}>{{ item.content }}</li>
+{% endfor %}

--- a/project/sites/etini/themes/etini_theme/templates/field/field--node--field-html-document--publication.html.twig
+++ b/project/sites/etini/themes/etini_theme/templates/field/field--node--field-html-document--publication.html.twig
@@ -1,0 +1,16 @@
+{#
+/**
+ * @file
+ * html document node, displayed in embed view mode.
+ *
+ * @see template_preprocess_node()
+ */
+#}
+{% for item in items %}
+  <a href="{{ item.content['#url'].toString() }}"
+     class="file-link file--ico file--ico__html" lang="{{ langcode }}">
+    {{ item.content['#title'] }}
+    <span class="meta">HTML document</span>
+  </a>
+{% endfor %}
+{{ title_suffix.contextual_links }}

--- a/project/sites/etini/themes/etini_theme/templates/field/field-group-html-element--node--group-documents.html.twig
+++ b/project/sites/etini/themes/etini_theme/templates/field/field-group-html-element--node--group-documents.html.twig
@@ -1,0 +1,24 @@
+{#
+/**
+ * @file
+ * Default theme implementation for a fieldgroup html element.
+ *
+ * Available variables:
+ * - title: Title of the group.
+ * - title_element: Element to wrap the title.
+ * - children: The children of the group.
+ * - wrapper_element: The html element to use
+ * - attributes: A list of HTML attributes for the group wrapper.
+ *
+ * @see template_preprocess_field_group_html_element()
+ *
+ * @ingroup themeable
+ */
+#}
+<h2 class="content-field__label">{{ 'Documents'|t }}</h2>
+<{{ wrapper_element }} {{ attributes }}>
+{{ children }}
+</{{ wrapper_element }}>
+<p class="help-viewing-documents">
+  <a href="{{ path('entity.node.canonical', {'node': '21'}) }}">{{ 'Help viewing documents'|t }}</a>
+</p>


### PR DESCRIPTION
- Adding the HTML document field to publications to allow entity reference content from a HTML document 
- Required styling templates to group HTML document under document section along with attachment field
- Added preprocess to theme file to assist this