### PR TITLE
CORP-713, CORP-716 & CORP-704

### DIFF
--- a/project/config/afbini/config/user.role.author_user.yml
+++ b/project/config/afbini/config/user.role.author_user.yml
@@ -76,6 +76,7 @@ permissions:
   - 'delete own page content'
   - 'delete own publication content'
   - 'delete own remote_video media'
+  - 'delete own researcher_profiles content'
   - 'edit any article content'
   - 'edit any contact content'
   - 'edit any gallery content'

--- a/project/config/etini/config/field.field.node.gallery.field_site_topics.yml
+++ b/project/config/etini/config/field.field.node.gallery.field_site_topics.yml
@@ -10,7 +10,7 @@ id: node.gallery.field_site_topics
 field_name: field_site_topics
 entity_type: node
 bundle: gallery
-label: 'Site topics'
+label: 'Organisational Phase'
 description: 'Choose relevant site topic(s) for this gallery.'
 required: false
 translatable: false

--- a/project/config/etini/config/field.field.node.link.field_site_topics.yml
+++ b/project/config/etini/config/field.field.node.link.field_site_topics.yml
@@ -10,7 +10,7 @@ id: node.link.field_site_topics
 field_name: field_site_topics
 entity_type: node
 bundle: link
-label: 'Site topics'
+label: 'Organisational phase'
 description: 'Choose optional site topics for this link.'
 required: false
 translatable: false

--- a/project/config/etini/config/field.field.node.news.field_site_topics.yml
+++ b/project/config/etini/config/field.field.node.news.field_site_topics.yml
@@ -12,7 +12,7 @@ id: node.news.field_site_topics
 field_name: field_site_topics
 entity_type: node
 bundle: news
-label: Topics
+label: 'Organisational phase'
 description: 'Choose optional site topic(s) for this news item.'
 required: false
 translatable: false

--- a/project/config/northsouthministerialcouncil/config/field.field.node.contact.field_site_topics.yml
+++ b/project/config/northsouthministerialcouncil/config/field.field.node.contact.field_site_topics.yml
@@ -12,7 +12,7 @@ id: node.contact.field_site_topics
 field_name: field_site_topics
 entity_type: node
 bundle: contact
-label: 'Site topics'
+label: 'Areas of Co-operation'
 description: 'Choose relevant site topic(s) for this point of contact.'
 required: false
 translatable: false

--- a/project/config/northsouthministerialcouncil/config/field.field.node.link.field_site_topics.yml
+++ b/project/config/northsouthministerialcouncil/config/field.field.node.link.field_site_topics.yml
@@ -10,7 +10,7 @@ id: node.link.field_site_topics
 field_name: field_site_topics
 entity_type: node
 bundle: link
-label: 'Site topics'
+label: 'Joint Communiques'
 description: 'Choose optional site topics for this link.'
 required: false
 translatable: false


### PR DESCRIPTION
CORP-713: Updating the label for the Site Topic's fields on various content types on ETINI to match the related taxonomy vocabulary name.
CORP-716: Updating the label for the Site Topic's fields on NSMC to match the related taxonomy vocabulary name.
CORP-704: Author profile did not have the option to delete own researcher profile content type, now enabled - AFBI