### PR TITLE
CORP-790

### DIFF
--- a/project/config/afbini/config/core.extension.yml
+++ b/project/config/afbini/config/core.extension.yml
@@ -119,7 +119,6 @@ module:
   origins_search_views_routing: 0
   origins_social_sharing: 0
   origins_toc: 0
-  origins_unique_title: 0
   page_cache: 0
   path: 0
   path_alias: 0

--- a/project/config/etini/config/core.extension.yml
+++ b/project/config/etini/config/core.extension.yml
@@ -116,7 +116,6 @@ module:
   origins_search_views_routing: 0
   origins_social_sharing: 0
   origins_toc: 0
-  origins_unique_title: 0
   page_cache: 0
   path: 0
   path_alias: 0

--- a/project/config/hseni/config/core.extension.yml
+++ b/project/config/hseni/config/core.extension.yml
@@ -115,7 +115,6 @@ module:
   origins_search_views_routing: 0
   origins_social_sharing: 0
   origins_toc: 0
-  origins_unique_title: 0
   page_cache: 0
   path: 0
   path_alias: 0

--- a/project/config/nisra/config/core.extension.yml
+++ b/project/config/nisra/config/core.extension.yml
@@ -122,7 +122,6 @@ module:
   origins_social_sharing: 0
   origins_toc: 0
   origins_translations: 0
-  origins_unique_title: 0
   page_cache: 0
   page_cache_exclusion: 0
   path: 0

--- a/project/config/northsouthministerialcouncil/config/core.extension.yml
+++ b/project/config/northsouthministerialcouncil/config/core.extension.yml
@@ -114,7 +114,6 @@ module:
   origins_search_views_routing: 0
   origins_social_sharing: 0
   origins_toc: 0
-  origins_unique_title: 0
   page_cache: 0
   path: 0
   path_alias: 0


### PR DESCRIPTION
- Uninstalling deprecated Unique Title module on all CORP LITE sites
- Origins:Forms now has the functionality and was already installed on all these sites